### PR TITLE
Detect source path even when flanked by slashes

### DIFF
--- a/src/util/paths.js
+++ b/src/util/paths.js
@@ -5,6 +5,10 @@ function normalisePath(path) {
 		.replace(/^\.\//g, '');
 }
 
+function removeLeadingAndTrailingSlashes(path) {
+	return path.replace(/^\/|\/$/g, '');
+}
+
 function stripTopPath(path, topPath) {
 	const normalisedTop = normalisePath(topPath);
 	return path.startsWith(normalisedTop) ? path.substring(normalisedTop.length) : path;
@@ -15,7 +19,7 @@ function isTopPath(basePath, index, basePaths) {
 }
 
 function getSourcePath(inputPath, source) {
-	return stripTopPath(normalisePath(inputPath), source).replace(/^\/+/, '');
+	return stripTopPath(normalisePath(inputPath), removeLeadingAndTrailingSlashes(source)).replace(/^\/+/, '');
 }
 
 module.exports = {

--- a/src/util/paths.js
+++ b/src/util/paths.js
@@ -6,7 +6,7 @@ function normalisePath(path) {
 }
 
 function removeLeadingAndTrailingSlashes(path) {
-	return path.replace(/^\/|\/$/g, '');
+	return path.replace(/^\/+|\/+$/g, '');
 }
 
 function stripTopPath(path, topPath) {

--- a/tests/util/items.test.js
+++ b/tests/util/items.test.js
@@ -89,6 +89,15 @@ test('processes item in custom source', async (t) => {
 	t.deepEqual(await processItem(customPage, 'pages', 'src'), processedPage);
 });
 
+test('processes item with custom source formatted differently', async (t) => {
+	const customPage = {
+		...page,
+		inputPath: './src/page.html'
+	};
+
+	t.deepEqual(await processItem(customPage, 'pages', '/src'), processedPage);
+});
+
 test('processes invalid item', async (t) => {
 	t.is(await processItem({}, 'pages', '.'), undefined);
 });


### PR DESCRIPTION
`getSourcePath` is supposed to remove the configured source path from collection item paths.

This doesn't work if the configured source starts with a slash - we assume the source has no leading/trailing slashes. We should handle this to prevent surprising results. 